### PR TITLE
Update llm and graph store configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2025-03-23] [PR#18](https://github.com/OpenWorkspace-o1/ow-camel-mem0-memory/pull/18)
+
+### Added
+- Added documentation for configuring `llm` with `anthropic` provider and `graph_store` with `neo4j` in `README.md`.
+- Added full configuration example including `llm` and `graph_store` settings.
+
 ## [2025-03-23] [PR#14](https://github.com/OpenWorkspace-o1/ow-camel-mem0-memory/pull/14)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ config = {
 
 Read more examples at [here](https://github.com/mem0ai/mem0/tree/04d7f2e48c8fc06b29f791f97052419c459f1c05/docs/components/embedders)
 
+### Configure LLM
+
+```bash
+config = {
+    "llm": {
+        "provider": "anthropic",
+        "config": {
+            "model": "claude-3-7-sonnet-latest",
+            "temperature": 0.2,
+            "max_tokens": 32768,
+        }
+    }
+}
+```
+
+Read more at [here](https://github.com/mem0ai/mem0/blob/04d7f2e48c8fc06b29f791f97052419c459f1c05/docs/components/llms/config.mdx)
+
 ### Full configuration
 
 ```bash
@@ -101,6 +118,14 @@ config = {
         "config": {
             "model": "text-embedding-3-large",
             "embedding_dims": 1536
+        }
+    },
+    "llm": {
+        "provider": "anthropic",
+        "config": {
+            "model": "claude-3-7-sonnet-latest",
+            "temperature": 0.2,
+            "max_tokens": 32768,
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,39 @@ config = {
 
 Read more at [here](https://github.com/mem0ai/mem0/blob/04d7f2e48c8fc06b29f791f97052419c459f1c05/docs/components/llms/config.mdx)
 
+### Configure Graph Store
+
+```bash
+config = {
+    "graph_store": {
+        "provider": "neo4j",
+        "config": {
+            "url": "neo4j+s://---",
+            "username": "neo4j",
+            "password": "---"
+        }
+    }
+}
+```
+
+Or with custom prompt
+
+```bash
+config = {
+    "graph_store": {
+        "provider": "neo4j",
+        "config": {
+            "url": "neo4j+s://xxx",
+            "username": "neo4j",
+            "password": "xxx"
+        },
+        "custom_prompt": "Please only extract entities containing sports related relationships and nothing else.",
+    }
+}
+```
+
+Read me at [here](https://github.com/mem0ai/mem0/blob/e4307ae42009e8e2a9dd66ca7ac74ff263bfcc54/docs/open-source/python-quickstart.mdx#L77)
+
 ### Full configuration
 
 ```bash
@@ -126,6 +159,14 @@ config = {
             "model": "claude-3-7-sonnet-latest",
             "temperature": 0.2,
             "max_tokens": 32768,
+        }
+    },
+    "graph_store": {
+        "provider": "neo4j",
+        "config": {
+            "url": "neo4j+s://---",
+            "username": "neo4j",
+            "password": "---"
         }
     }
 }


### PR DESCRIPTION
### **PR Type**
Documentation, Configuration

___

### **PR Description**
- Added documentation for configuring `llm` and `graph_store` in the `README.md`.
  - Includes examples for setting up `llm` with `anthropic` provider and `graph_store` with `neo4j`.

- Updated full configuration example to include `llm` and `graph_store` settings.
