### PR TITLE
Fix install package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2025-03-23] [PR#20](https://github.com/OpenWorkspace-o1/ow-camel-mem0-memory/pull/20)
+
+### Updated
+- Updated package installation command in `README.md` from `openworkspace-o1-camel-mem0` to `ow-camel-mem0-memory`.
+- Fixed a typo in the documentation link text from "Read me" to "Read more".
+
 ## [2025-03-23] [PR#18](https://github.com/OpenWorkspace-o1/ow-camel-mem0-memory/pull/18)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ config = {
 }
 ```
 
-Read me at [here](https://github.com/mem0ai/mem0/blob/e4307ae42009e8e2a9dd66ca7ac74ff263bfcc54/docs/open-source/python-quickstart.mdx#L77)
+Read more at [here](https://github.com/mem0ai/mem0/blob/e4307ae42009e8e2a9dd66ca7ac74ff263bfcc54/docs/open-source/python-quickstart.mdx#L77)
 
 ### Full configuration
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package implements a Mem0-based storage backend for CamelAI agents, allowin
 ## Installation
 
 ```bash
-pip install openworkspace-o1-camel-mem0
+pip install ow-camel-mem0-memory
 ```
 
 ## Usage


### PR DESCRIPTION
### **PR Type**
Documentation, Configuration

___

### **PR Description**
- Updated package installation command from `openworkspace-o1-camel-mem0` to `ow-camel-mem0-memory`.

- Fixed a typo in the documentation link text from "Read me" to "Read more".
