### PR TITLE
camel-ai>=0.2.42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.aider*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10,<3.13"
 readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
-    "camel-ai>=0.2.41",
+    "camel-ai>=0.2.42",
     "mem0ai>=0.1.81",
     "sqlalchemy==2.0.40",
     "psycopg2-binary==2.9.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-camel-ai>=0.2.41
+camel-ai>=0.2.42
 mem0ai>=0.1.81
 ruff==0.11.4
 sqlalchemy==2.0.40


### PR DESCRIPTION
### **PR Type**
Dependencies

___

### **PR Description**
- Updated `camel-ai` dependency from version `0.2.41` to `0.2.42` in `pyproject.toml` and `requirements.txt`.
